### PR TITLE
Remove direct paths in npm scripts definitions

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,9 +25,9 @@
         "uglify-js": "2.4.x"
     },
     "scripts": {
-        "lint": "./node_modules/.bin/jshint ./src/check-types.js --config config/jshint.json",
-        "test": "./node_modules/.bin/mocha --ui tdd --reporter spec --colors ./test/check-types.js",
-        "minify": "./node_modules/.bin/uglifyjs ./src/check-types.js --compress --mangle --output ./src/check-types.min.js"
+        "lint": "jshint ./src/check-types.js --config config/jshint.json",
+        "test": "mocha --ui tdd --reporter spec --colors ./test/check-types.js",
+        "minify": "uglifyjs ./src/check-types.js --compress --mangle --output ./src/check-types.min.js"
     }
 }
 


### PR DESCRIPTION
NPM already puts dependencies in PATH:
https://www.npmjs.org/doc/misc/npm-scripts.html#path
