### PR TITLE
Limit packaging extraneous files

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,6 +38,8 @@
         "lint": "jshint ./src/check-types.js",
         "test": "mocha --ui tdd --reporter spec --colors ./test/check-types.js",
         "minify": "uglifyjs ./src/check-types.js --compress --mangle --output ./src/check-types.min.js"
-    }
+    },
+    "files": [
+        "src"
+    ]
 }
-


### PR DESCRIPTION
This will tell npm to package only the contents of the src folder when versioning (along with the license and readme), meaning that files like `bower.json` and `travis.yml` will be excluded from future versions.

https://docs.npmjs.com/files/package.json#files